### PR TITLE
Fix GaussianProcessClassifier output handling

### DIFF
--- a/AFL/double_agent/Extrapolator.py
+++ b/AFL/double_agent/Extrapolator.py
@@ -322,18 +322,20 @@ class GaussianProcessClassifier(Extrapolator):
         """
         X = dataset[self.feature_input_variable].transpose(self.sample_dim, ...)
         y = dataset[self.predictor_input_variable].transpose(self.sample_dim, ...)
-        self.grid = dataset[self.grid_variable]# store grid for plotting
+        self.grid = dataset[self.grid_variable]  # store grid for plotting
 
         if len(np.unique(y)) == 1:
 
+            grid_shape = dataset[self.grid_variable].shape
+
             self.output[self._prefix_output("mean")] = xr.DataArray(
-                np.ones(dataset.grid.shape), dims=[self.grid_dim]
+                np.ones(grid_shape), dims=[self.grid_dim]
             )
             self.output[self._prefix_output("entropy")] = xr.DataArray(
-                np.ones(dataset.grid.shape), dims=[self.grid_dim]
+                np.ones(grid_shape), dims=[self.grid_dim]
             )
             self.output[self._prefix_output("y_prob")] = xr.DataArray(
-                np.ones(dataset.grid.shape), dims=[self.grid_dim]
+                np.ones(grid_shape), dims=[self.grid_dim]
             )
 
         else:
@@ -357,7 +359,7 @@ class GaussianProcessClassifier(Extrapolator):
                 entropy, dims=self.grid_dim
             )
             self.output[self._prefix_output("y_prob")] = xr.DataArray(
-                entropy, dims=self.grid_dim
+                y_prob, dims=self.grid_dim
             )
 
         return self


### PR DESCRIPTION
## Summary
- fix use of `dataset.grid` in `GaussianProcessClassifier`
- output proper shape and values for `y_prob`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68530c585df8832195222783bf706dda