### PR TITLE
Fix utils filename in tests README

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ This directory contains tests for the AFL.double_agent module. The test suite is
 ## Structure
 
 - **`test_\*`**: Unit and integration tests for individual components, and interacting components
-- **`uitls.py`**: Mock classes and helper methods for tests
+- **`utils.py`**: Mock classes and helper methods for tests
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- correct the path to `utils.py` in tests README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530f060d64832182e5c120f871dc3d