### PR TITLE
Fix undefined variable in ArrayToVars.calculate

### DIFF
--- a/AFL/double_agent/Preprocessor.py
+++ b/AFL/double_agent/Preprocessor.py
@@ -910,7 +910,7 @@ class ArrayToVars(Preprocessor):
     def calculate(self, dataset):
         input_arr = dataset[self.input_variable]
         if self.squeeze:
-            output = output.squeeze()
+            input_arr = input_arr.squeeze()
         for var in self.output_variables:
             print(var)
 


### PR DESCRIPTION
## Summary
- fix a variable reference in ArrayToVars.calculate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530eff56348321a81023e7fdeba5a9