### PR TITLE
Fix typo in AcquisitionFunction error message

### DIFF
--- a/AFL/agent/AcquisitionFunction.py
+++ b/AFL/agent/AcquisitionFunction.py
@@ -233,7 +233,7 @@ class LowestDensity(Acquisition):
             self.y_mean = y_mean
             self.y_var = y_var
         else:
-            raise ValueError('Need to pass either GP or y_mean/y_var into calcualte_metric!')
+            raise ValueError('Need to pass either GP or y_mean/y_var into calculate_metric!')
             
 
         GP_domain_transform = self.phasemap.attrs.get('GP_domain_transform',None)


### PR DESCRIPTION
## Summary
- correct typo in `AcquisitionFunction.calculate_metric`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530ef7b45c8321a787aff882895e73