### PR TITLE
Add cluster membership probability operation

### DIFF
--- a/tests/test_membership_probability.py
+++ b/tests/test_membership_probability.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from AFL.double_agent.Labeler import ClusterMembershipProbability
+
+
+@pytest.mark.unit
+def test_membership_probability(example_dataset1_cluster_result):
+    op = ClusterMembershipProbability(
+        similarity_variable="similarity",
+        labels_variable="labels",
+        output_variable="probs",
+        sample_dim="sample",
+    )
+
+    op.calculate(example_dataset1_cluster_result)
+    probs = op.output["probs"]
+
+    assert probs.dims[0] == "sample"
+    assert np.allclose(probs.sum(dim="cluster"), 1.0)
+    assert probs.shape[0] == example_dataset1_cluster_result.dims["sample"]


### PR DESCRIPTION
## Summary
- add `ClusterMembershipProbability` to compute membership probabilities from a similarity matrix
- unit test for new operation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853193b45f48321a844b4e706c62209